### PR TITLE
Added caveat handling during relationship creation

### DIFF
--- a/SpiceDb/Models/Relationship.cs
+++ b/SpiceDb/Models/Relationship.cs
@@ -7,6 +7,7 @@ public class Relationship
         Resource = resource;
         Relation = relation;
         Subject = subject;
+        OptionalCaveat = optionalCaveat;
 
         if (!string.IsNullOrEmpty(Resource.Relation))
         {


### PR DESCRIPTION
Added handling of caveat when adding relationships. Currently they are omitted, but it should be possible in case when you want to set some context values for caveats during relationship creation.