### PR TITLE
Added caveat handling during relationship creation

### DIFF
--- a/SpiceDb/Models/Relationship.cs
+++ b/SpiceDb/Models/Relationship.cs
@@ -7,6 +7,7 @@ public class Relationship
         Resource = resource;
         Relation = relation;
         Subject = subject;
+        OptionalCaveat = optionalCaveat;
 
         if (!string.IsNullOrEmpty(Resource.Relation))
         {


### PR DESCRIPTION
Added handling of optional caveats when calling AddRelationship, AddRelationshipAsync and WriteRelationships.
Caveats should be allowed to set during creation in case when there is necessity to add full or partial context (for example, whitelist).