### PR TITLE
SpiceDB: Allow empty schema prefix for dedicated version of SpiceDB

### DIFF
--- a/SpiceDb/Models/ResourceReference.cs
+++ b/SpiceDb/Models/ResourceReference.cs
@@ -46,7 +46,7 @@ public class ResourceReference
     /// <summary>
     /// Sets up a resource reference that can reference a specific relation/permission inside an object
     /// For example: organization:easd may be an original reference, but to reference members of easd
-    /// the reference should be: organization:easd#members 
+    /// the reference should be: organization:easd#members
     /// </summary>
     /// <param name="relation"></param>
     /// <returns></returns>
@@ -55,6 +55,10 @@ public class ResourceReference
     public ResourceReference EnsurePrefix(string prefix)
     {
         var type = this.Type;
+        if (string.IsNullOrEmpty(prefix))
+        {
+            return  new ResourceReference(type, this.Id, this.Relation);
+        }
         type = string.IsNullOrEmpty(type) ? type : type.StartsWith(prefix + "/") ? type : $"{prefix}/{type}";
 
         if (type == this.Type)
@@ -63,9 +67,13 @@ public class ResourceReference
         return new ResourceReference(type, this.Id, this.Relation);
     }
 
-    public ResourceReference ExcludePrefix(string prefix)
+    public ResourceReference ExcludePrefix(string? prefix)
     {
         var type = this.Type;
+        if (string.IsNullOrEmpty(prefix))
+        {
+            return  new ResourceReference(type, this.Id, this.Relation);
+        }
 
         if (!prefix.EndsWith("/")) prefix += "/";
 

--- a/SpiceDb/SpiceDbClient.cs
+++ b/SpiceDb/SpiceDbClient.cs
@@ -13,9 +13,9 @@ using System.Text.RegularExpressions;
 
 namespace SpiceDb;
 
-public class SpiceDbClient : ISpiceDbClient
+public sealed class SpiceDbClient : ISpiceDbClient
 {
-    private readonly string _prefix;
+    private readonly string? _prefix;
     private readonly SpiceDbCore _spiceDbCore;
 
     /// <summary>
@@ -34,12 +34,12 @@ public class SpiceDbClient : ISpiceDbClient
     /// <param name="token">The token with admin privileges for manipulating the desired permission system.</param>
     /// <param name="schemaPrefix">The schema prefix used for the permission system.</param>
     /// <exception cref="Exception">Thrown when the server address or token is null or empty, or if the schema prefix does not meet the required format.</exception>
-    public SpiceDbClient(string serverAddress, string token, string schemaPrefix)
+    public SpiceDbClient(string serverAddress, string token, string? schemaPrefix)
     {
         if (string.IsNullOrEmpty(serverAddress) || !serverAddress.StartsWith("http"))
             throw new ArgumentException("Expecting http:// or https:// in the SpiceDb endpoint.");
 
-        if (!Regex.IsMatch(schemaPrefix, @"^[a-zA-Z0-9_]{3,63}[a-zA-Z0-9]$"))
+        if (schemaPrefix is not null && !Regex.IsMatch(schemaPrefix, @"^[a-zA-Z0-9_]{3,63}[a-zA-Z0-9]$"))
             throw new Exception(
                 "Schema prefixes must be alphanumeric, lowercase, between 4-64 characters and not end in an underscore");
 
@@ -675,7 +675,7 @@ public class SpiceDbClient : ISpiceDbClient
 
     private string? EnsurePrefix(string? type)
     {
-        if (string.IsNullOrEmpty(type)) return type;
+        if (string.IsNullOrEmpty(type) || string.IsNullOrEmpty(_prefix)) return type;
 
         return type.StartsWith(_prefix + "/") ? type : $"{_prefix}/{type}";
     }


### PR DESCRIPTION
Hello!

I'm working on a new project including AuthZed dedicated version (still under test for us).

To give a bit of context: AuthZed dedicated version don't have any schema prefix, so I'm adapting your lib to the need that we have.

Let me know if my changes sounds good to you or if you have questions, recommendations! 

Just so you know I'm unable to run the test you had in place, probably a config issue on my hand but it looks like tests are not really thing so far on your project!

thanks