### PR TITLE
Fixing memory leak caused by missing using statment

### DIFF
--- a/SpiceDb/Api/SpiceDbPermissions.cs
+++ b/SpiceDb/Api/SpiceDbPermissions.cs
@@ -327,7 +327,8 @@ internal class SpiceDbPermissions
         {
             req.Consistency.FullyConsistent = true;
         }
-        var call = _acl!.ReadRelationships(req);
+        
+        using var call = _acl!.ReadRelationships(req);
 
         await foreach (var resp in call.ResponseStream.ReadAllAsync())
         {


### PR DESCRIPTION
We noticed a memory when using `ReadRelationshipsAsync` and tracked it down to calls not being removed from the channel.

The call is disposable and the documentation shows usage with a `using` statement.

https://learn.microsoft.com/en-us/aspnet/core/grpc/client?view=aspnetcore-9.0#server-streaming-call

```
var client = new Greet.GreeterClient(channel);
using var call = client.SayHellos(new HelloRequest { Name = "World" });

while (await call.ResponseStream.MoveNext())
{
    Console.WriteLine("Greeting: " + call.ResponseStream.Current.Message);
    // "Greeting: Hello World" is written multiple times
}
```