### PR TITLE
fix: apply correct logic to consistency

### DIFF
--- a/SpiceDb/Enum/CacheFreshness.cs
+++ b/SpiceDb/Enum/CacheFreshness.cs
@@ -4,5 +4,6 @@ public enum CacheFreshness
 {
     AnyFreshness,
     AtLeastAsFreshAs,
-    MustRefresh
+    MustRefresh,
+    AtExactSnapshot
 }


### PR DESCRIPTION
Fixes #30 

* Adds `AtExactSnapshot` consistency option
* Applies the appropriate consistency to the request based on the provided options
* `zedToken` is ignored when using `AnyFreshness` / `MustRefresh`
* When `zedToken` is not provided and `AtLeastAsFreshAs` or `AtExactSnapshot` is specified, an exception is thrown